### PR TITLE
Fix paypal subscription error for espaLuz

### DIFF
--- a/src/components/PayPalButton.tsx
+++ b/src/components/PayPalButton.tsx
@@ -139,22 +139,7 @@ const PayPalButton = ({ planType, onSuccess, onError }: PayPalButtonProps) => {
           console.log('Creating PayPal subscription with plan ID:', planId);
           
           return actions.subscription.create({
-            'plan_id': planId,
-            'subscriber': {
-              'name': {
-                'given_name': user?.user_metadata?.full_name?.split(' ')[0] || 'EspaLuz',
-                'surname': user?.user_metadata?.full_name?.split(' ')[1] || 'Subscriber'
-              },
-              'email_address': user?.email || ''
-            },
-            'application_context': {
-              'brand_name': 'EspaLuz',
-              'user_action': 'SUBSCRIBE_NOW',
-              'payment_method': {
-                'payer_selected': 'PAYPAL',
-                'payee_preferred': 'IMMEDIATE_PAYMENT_REQUIRED'
-              }
-            }
+            'plan_id': planId
           });
         },
         onApprove: async function(data: any, actions: any) {

--- a/src/components/Pricing.tsx
+++ b/src/components/Pricing.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Check, Star } from "lucide-react";
 import { Link } from "react-router-dom";
 import PayPalButton from "./PayPalButton";
+import { PAYPAL_CONFIG } from "@/config/paypal";
 
 const Pricing = () => {
   const plans = [
@@ -39,7 +40,7 @@ const Pricing = () => {
       popular: true,
       paypal: true,
       comingSoon: false,
-      merchantId: "P8TXABNT28ZXG"
+      merchantId: PAYPAL_CONFIG.merchantId
     },
     {
       name: "Premium",


### PR DESCRIPTION
Simplify PayPal subscription payload and unify merchant ID to resolve subscription errors.

The PayPal `createSubscription` API often fails when extraneous fields are included, causing "Something went wrong" errors. This change removes those fields. The merchant ID was also hardcoded inconsistently, which is now resolved.

---
<a href="https://cursor.com/background-agent?bcId=bc-b7f5976a-827c-4783-9bbf-e2d44e9d5e6d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b7f5976a-827c-4783-9bbf-e2d44e9d5e6d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

